### PR TITLE
Development - fix/mongodb-pipeline

### DIFF
--- a/RecallAIsh/vector_store/mongodb_store.py
+++ b/RecallAIsh/vector_store/mongodb_store.py
@@ -29,16 +29,20 @@ class MongoDBVectorStore(BaseVectorStore):
             index_result = self.collection.create_search_index(
                 operations.SearchIndexModel(
                     definition={
-                        "fields": [
-                            {
-                                "type": "vector",
-                                "path": "embedding",
-                                "numDimensions": dimensions,
-                                "similarity": similarity,
-                                "quantization": "scalar",
-                            }
-                        ]
-                    },
+                    "fields": [
+                        {
+                            "type": "vector",
+                            "path": "embedding",
+                            "numDimensions": dimensions,
+                            "similarity": similarity,
+                            "quantization": "scalar",
+                        },
+                        {
+                            "type": "token",
+                            "path": "metadata.file_type"  # Adding metadata.file_type for filtering
+                        }
+                    ]
+                },
                     name=self.index_name,
                     type="vectorSearch",
                 )
@@ -67,7 +71,7 @@ class MongoDBVectorStore(BaseVectorStore):
         }
 
         if filter:
-            vector_search_stage["filter"] = filter  # Fixing incorrect curly braces
+            vector_search_stage["$vectorSearch"]["filter"] = filter  # Fixing incorrect curly braces
 
         pipeline = [
             vector_search_stage,

--- a/RecallAIsh/vector_store/mongodb_store.py
+++ b/RecallAIsh/vector_store/mongodb_store.py
@@ -24,7 +24,7 @@ class MongoDBVectorStore(BaseVectorStore):
         self._create_vector_index(dimensions=dimensions, similarity=similarity)
 
     def _create_vector_index(self, dimensions: int, similarity: str):
-        # Create the vector index with the specified dimensions and similarity metric
+        # Create the vector index with the specified dimensions and similarity metrics
         try:
             index_result = self.collection.create_search_index(
                 operations.SearchIndexModel(


### PR DESCRIPTION
fix: mongodb pipeline error and index token issue

Fixed the issue: A pipeline stage specification object must contain exactly one field. 
Consequently, fixed another error raised 'pymongo.errors.OperationFailure: PlanExecutor error during aggregation :: caused by :: Path 'metadata.file_type' needs to be indexed as token'